### PR TITLE
Fix build, automate test

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,6 +9,8 @@ RUN apt-get -q update && apt-get install -yq --no-install-recommends \
 # Switch to working directory for our app
 WORKDIR /usr/src/app
 
+COPY test.sh test.sh
+
 # Clone and compile Kunbus's piTest binary
 RUN git clone https://github.com/RevolutionPi/piControl
 RUN cd /usr/src/app/piControl/piTest && make
@@ -17,4 +19,4 @@ RUN cd /usr/src/app/piControl/piTest && make
 ENV INITSYSTEM on
 
 # Sleep as we execute the remaining part of the test manually
-CMD sleep 10000000
+CMD [ "bash", "./test.sh" ]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:jessie
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:latest
 
 # Install build tools and remove layer cache afterwards
 RUN apt-get -q update && apt-get install -yq --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 > Based on how you connect the DIO module, change the “position” to “32” (if the module is on the right of the RevPi Core) or “31” (if the module is on the left of the RevPi Core) inside the file config.rsc contained inside the test application
 
 3. Flash and boot your device
-4. Enter the container (from either the dashboard or using [balena-cli](https://github.com/balena-io/balena-cli))
-5. Run the following tests:
-
-- a) `piControl/piTest/piTest -w O_1,1`: upper right pin of the DIO module should have the same voltage as the board
+4. Connect output O1 to the input I1 on the RevPi DIO with a wire
+5. Wait for the device to come up online and run the container
+6. Inspect container logs, it should output "TEST PASSED"
+7. For debugging purposes, enter the container terminal (from either the dashboard or using [balena-cli](https://github.com/balena-io/balena-cli))
+- a) disconnect jumper wire from O1 and I1 and run the following tests:
+- b) `piControl/piTest/piTest -w O_1,1`: upper right pin (O1) of the DIO module should have the same voltage as the board
 power input
-- b) `piControl/piTest/piTest -w O_1,0`: uperr right pin of the DIO module should be at 0V
+- c) `piControl/piTest/piTest -w O_1,0`: uperr right pin (O1) of the DIO module should be at 0V

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+ret=0;
+
+./piControl/piTest/piTest -w O_1,1
+sleep 1
+res=$(./piControl/piTest/piTest -1r I_1)
+
+if [[ "$res" != "Bit value: 1" ]]; then
+        echo "TEST 1: Failed!"
+        ret=1;
+fi;
+
+./piControl/piTest/piTest -w O_1,0
+sleep 1
+res=$(./piControl/piTest/piTest -1r I_1)
+
+if [[ "$res" != "Bit value: 0" ]]; then
+        echo "TEST 2: Failed!"
+        ret=1;
+fi;
+
+if [ $ret -eq 0 ]; then
+        echo "TEST PASSED"
+else
+        echo "TEST FAILED"
+fi
+
+while true; do
+        sleep 1
+done


### PR DESCRIPTION
Fix build and automate testing steps
    
    Update base image to latest version to fix dependencies install

    Add script to test RevPi DIO module automatically.
    
    It is expected that ports O1 (upper right)
    and I1 (lower right) on the RevPi DIO are
    connected together by a wire.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>